### PR TITLE
fix(ssl) single settimeout call per socket

### DIFF
--- a/spec/02-integration/08_ssl_spec.lua
+++ b/spec/02-integration/08_ssl_spec.lua
@@ -80,7 +80,7 @@ desc("SSL", function()
         }
       }
       assert.truthy(err)
-      assert.equal("SocketError", err.type)
+      assert.equal("SSLError", err.type)
       assert.falsy(session)
     end)
 

--- a/src/cassandra/errors.lua
+++ b/src/cassandra/errors.lua
@@ -35,6 +35,9 @@ local ERROR_TYPES = {
       return message.." for socket with peer "..address
     end
   },
+  SSLError = {
+    info = "Represents an error happening during the SSL handshake."
+  },
   TimeoutError = {
     info = "Represents a client-side error that is raised when the client didn't hear back from the server within {client_options.socket_options.read_timeout}.",
     message = function(address)
@@ -42,7 +45,7 @@ local ERROR_TYPES = {
     end
   },
   AuthenticationError = {
-    info = "Represents an authentication error from the driver or from a Cassandra node."
+    info = "Represents an error happening during the authentication flow."
   },
   SharedDictError = {
     info = "Represents an error with the lua_shared_dict in use.",


### PR DESCRIPTION
- fix LuaSec timing out because multiple settimeout calls on the socket
  used to actually trigger timeouts.
- actually, this change is also benefitial to regular luasocket or
  cosocket usage.
- new SSLError type
- close socket on timeout