### PR TITLE
feat(ngx_lua) support for all non-cosocket contexts

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -5,9 +5,7 @@ set -e
 if [ "$OPENRESTY_TESTS" != "yes" ]; then
   make lint
   busted -v --coverage -o gtest --repeat 1
-  luacov-coveralls -i src/cassandra -e bit.lua
+  luacov-coveralls -i src/cassandra -e bit.lua -e socket.lua
 else
-  ccm create resty_tests -v binary:$CASSANDRA -n 1
-  ccm start --wait-for-binary-proto
-  prove -l t
+  make prove
 fi

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,3 +1,0 @@
-unused_args = false
-redefined = false
-globals = {"ngx", "describe", "setup", "teardown", "it", "pending", "before_each", "after_each", "finally", "spy", "mock"}

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-DEV_ROCKS=busted luacov luasec luacov-coveralls luacheck ldoc
+DEV_ROCKS=busted luacov-coveralls luacheck ldoc
 
-.PHONY: install dev test prove clean coverage lint doc
+.PHONY: install dev busted prove test clean coverage lint doc
 
 install:
-	@luarocks make lua-cassandra-*.rockspec
+	@luarocks make
 
 dev: install
 	@for rock in $(DEV_ROCKS); do\
@@ -15,22 +15,26 @@ dev: install
 		fi\
 	done;
 
-test:
+busted:
 	@busted -v -o gtest
 
 prove:
+	@util/prove_ccm.sh
 	@util/reindex t/* && prove
+
+test: busted prove
 
 clean:
 	@rm -f luacov.*
 	@util/clean_ccm.sh
 
 coverage: clean
-	@busted -v --coverage
+	@busted -v -o gtest --coverage
 	@luacov cassandra
 
 lint:
-	@find src spec -not -path './doc/*' -name '*.lua' | xargs luacheck -q
+	@luacheck -q src --std ngx_lua --no-redefined --no-unused-args
+	@luacheck -q spec --std 'lua51+busted' --no-redefined --no-unused-args
 
 doc:
 	@ldoc -c doc/config.ld src

--- a/lua-cassandra-0.5.0-0.rockspec
+++ b/lua-cassandra-0.5.0-0.rockspec
@@ -20,6 +20,7 @@ build = {
     ["cassandra.log"] = "src/cassandra/log.lua",
     ["cassandra.cache"] = "src/cassandra/cache.lua",
     ["cassandra.errors"] = "src/cassandra/errors.lua",
+    ["cassandra.socket"] = "src/cassandra/socket.lua",
     ["cassandra.options"] = "src/cassandra/options.lua",
     ["cassandra.requests"] = "src/cassandra/requests.lua",
     ["cassandra.frame_reader"] = "src/cassandra/frame_reader.lua",

--- a/spec/02-integration/02_session_spec.lua
+++ b/spec/02-integration/02_session_spec.lua
@@ -20,37 +20,6 @@ describe("session", function()
     session:execute "SELECT * FROM system.local"
   end)
 
-  describe("luasocket fallback", function()
-    it("should fallback on proxy socket", function()
-      local socket = session.hosts[1].socket
-      assert.True(socket.fallback)
-    end)
-    it("should proxy settimeout()", function()
-      local socket = session.hosts[1].socket
-      local mt = getmetatable(socket)
-      assert.truthy(mt)
-
-      spy.on(mt, "settimeout")
-
-      local session_t = cassandra.spawn_session {
-        shm = _shm,
-        socket_options = {
-          connect_timeout = 1000,
-          read_timeout = 1000
-        }
-      }
-
-      -- force connect
-      session_t:execute "SELECT * FROM system.local"
-
-      assert.spy(mt.settimeout).was.called(2) -- connect + read timeout
-    end)
-    it("should proxy getreusedtimes()", function()
-      local socket = session.hosts[1].socket
-      assert.equal(0, socket:getreusedtimes())
-    end)
-  end)
-
   describe("set_keyspace()", function()
     it("should set a session's 'keyspace' option", function()
       local ok, err = session:set_keyspace "system"

--- a/spec/02-integration/02_session_spec.lua
+++ b/spec/02-integration/02_session_spec.lua
@@ -2,18 +2,53 @@ local utils = require "spec.spec_utils"
 local cassandra = require "cassandra"
 
 describe("session", function()
-  local session, err, _hosts, _shm
+  local session, _hosts, _shm
 
   setup(function()
     _hosts, _shm = utils.ccm_start()
   end)
 
   before_each(function()
+    local err
     session, err = cassandra.spawn_session {
       shm = _shm,
       contact_points = _hosts
     }
     assert.falsy(err)
+
+    -- force connect
+    session:execute "SELECT * FROM system.local"
+  end)
+
+  describe("luasocket fallback", function()
+    it("should fallback on proxy socket", function()
+      local socket = session.hosts[1].socket
+      assert.True(socket.fallback)
+    end)
+    it("should proxy settimeout()", function()
+      local socket = session.hosts[1].socket
+      local mt = getmetatable(socket)
+      assert.truthy(mt)
+
+      spy.on(mt, "settimeout")
+
+      local session_t = cassandra.spawn_session {
+        shm = _shm,
+        socket_options = {
+          connect_timeout = 1000,
+          read_timeout = 1000
+        }
+      }
+
+      -- force connect
+      session_t:execute "SELECT * FROM system.local"
+
+      assert.spy(mt.settimeout).was.called(2) -- connect + read timeout
+    end)
+    it("should proxy getreusedtimes()", function()
+      local socket = session.hosts[1].socket
+      assert.equal(0, socket:getreusedtimes())
+    end)
   end)
 
   describe("set_keyspace()", function()

--- a/src/cassandra/socket.lua
+++ b/src/cassandra/socket.lua
@@ -1,0 +1,110 @@
+local get_phase, ngx_socket, has_cosocket, log, warn
+
+--- ngx_lua utils
+
+if ngx ~= nil then
+  get_phase = ngx.get_phase
+  ngx_socket = ngx.socket
+  log = ngx.log
+  warn = ngx.WARN
+  has_cosocket = function()
+    local phase = get_phase()
+    return phase == "rewrite" or phase == "access"
+        or phase == "content" or phase == "timer"
+  end
+else
+  log = function()end
+  get_phase = function()end
+  has_cosocket = function()end
+end
+
+--- LuaSocket proxy metatable
+
+local luasocket_mt = {}
+
+function luasocket_mt:__index(key)
+  local override = rawget(luasocket_mt, key)
+  if override ~= nil then
+    return override
+  end
+
+  local orig = self.sock[key]
+  if type(orig) == "function" then
+    local f = function(_, ...)
+      return orig(self.sock, ...)
+    end
+    self[key] = f
+    return f
+  end
+
+  return orig
+end
+
+
+--- LuaSocket <-> ngx_lua compat
+
+function luasocket_mt.getreusedtimes()
+  return 0
+end
+
+function luasocket_mt:settimeout(t)
+  self.sock:settimeout(t/1000)
+end
+
+function luasocket_mt:setkeepalive()
+  self.sock:close()
+  return true
+end
+
+--- Perform SSL handshake.
+-- Mimics the ngx_lua `sslhandshake()` signature with an additional argument
+-- to specify the certificate authority file since ngx_lua won't allow us to
+-- retrieve the configuration value.
+function luasocket_mt:sslhandshake(reused_session, _, verify, luasec_opts)
+  local return_bool = reused_session == false
+
+  local ssl = require "ssl"
+  local params = {
+    mode = "client",
+    protocol = "tlsv1",
+    key = luasec_opts.key,
+    certificate = luasec_opts.certificate,
+    cafile = luasec_opts.ca,
+    verify = verify and "peer" or "none",
+    options = "all"
+  }
+
+  local ssl_sock, err = ssl.wrap(self.sock, params)
+  if err then
+    return return_bool and false or nil, err
+  end
+
+  local ok, err = ssl_sock:dohandshake()
+  if not ok then
+    return return_bool and false or nil, err
+  end
+
+  self.sock = ssl_sock
+
+  return return_bool and true or ssl_sock
+end
+
+--- Module
+
+return {
+  tcp = function(...)
+    if has_cosocket() then
+      return ngx_socket.tcp(...)
+    else
+      log(warn, "no support for cosockets in this context, falling back on LuaSocket")
+
+      local socket = require "socket"
+
+      return setmetatable({
+        sock = socket.tcp(...)
+      }, luasocket_mt)
+    end
+  end,
+  luasocket_mt = luasocket_mt,
+  _VERSION = "0.0.1"
+}

--- a/t/01-spawn.t
+++ b/t/01-spawn.t
@@ -1,6 +1,8 @@
 use Test::Nginx::Socket::Lua;
 use t::Utils;
 
+log_level('error');
+
 plan tests => repeat_each() * blocks() * 3 + (repeat_each() * 2);
 
 run_tests();
@@ -164,6 +166,7 @@ local
 
 
 === TEST 6: spawn session without cluster with contact_points
+--- log_level: info
 --- http_config eval
 "$t::Utils::HttpConfig"
 --- config

--- a/t/02-session.t
+++ b/t/02-session.t
@@ -1,6 +1,8 @@
 use Test::Nginx::Socket::Lua;
 use t::Utils;
 
+log_level('error');
+
 plan tests => repeat_each() * blocks() * 3;
 
 run_tests();

--- a/t/03-execute.t
+++ b/t/03-execute.t
@@ -1,6 +1,8 @@
 use Test::Nginx::Socket::Lua;
 use t::Utils;
 
+log_level('error');
+
 plan tests => repeat_each() * blocks() * 3;
 
 run_tests();

--- a/t/04-batch.t
+++ b/t/04-batch.t
@@ -1,6 +1,8 @@
 use Test::Nginx::Socket::Lua;
 use t::Utils;
 
+log_level('error');
+
 repeat_each(2);
 
 plan tests => repeat_each() * blocks() * 3;

--- a/t/10-contexts.t
+++ b/t/10-contexts.t
@@ -1,0 +1,413 @@
+use Test::Nginx::Socket::Lua;
+use t::Utils;
+
+repeat_each(3);
+
+plan tests => repeat_each() * blocks() * 3;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: support in init
+--- http_config eval
+"$t::Utils::HttpConfig
+lua_shared_dict test 128k;
+init_by_lua_block {
+    local dict = ngx.shared.test
+    local cassandra = require 'cassandra'
+    local session = cassandra.spawn_session {
+        shm = 'cassandra',
+        contact_points = {'127.0.0.1'}
+    }
+
+    local rows = session:execute 'SELECT key FROM system.local'
+    local socket = session.hosts[1].socket
+
+    dict:set('cosocket', socket.setkeepalive ~= nil)
+    dict:set('type', rows.type)
+    dict:set('length', #rows)
+    dict:set('key', rows[1].key)
+}
+"
+--- config
+    location /t {
+        content_by_lua_block {
+            local dict = ngx.shared.test
+            ngx.say(dict:get("type"))
+            ngx.say(dict:get("length"))
+            ngx.say(dict:get("key"))
+            ngx.say(dict:get("cosocket"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+ROWS
+1
+local
+false
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: suppoer in init_worker
+--- http_config eval
+"$t::Utils::HttpConfig
+lua_shared_dict test 128k;
+init_worker_by_lua_block {
+    local dict = ngx.shared.test
+    local cassandra = require 'cassandra'
+    local session = cassandra.spawn_session {
+        shm = 'cassandra',
+        contact_points = {'127.0.0.1'}
+    }
+
+    local rows = session:execute 'SELECT key FROM system.local'
+    local socket = session.hosts[1].socket
+
+    dict:set('cosocket', socket.setkeepalive ~= nil)
+    dict:set('type', rows.type)
+    dict:set('length', #rows)
+    dict:set('key', rows[1].key)
+}"
+--- config
+    location /t {
+        content_by_lua_block {
+            local dict = ngx.shared.test
+            ngx.say(dict:get("type"))
+            ngx.say(dict:get("length"))
+            ngx.say(dict:get("key"))
+            ngx.say(dict:get("cosocket"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+ROWS
+1
+local
+false
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: suppoer in set
+--- http_config eval
+"$t::Utils::HttpConfig"
+--- config
+    location /t {
+        set_by_lua_block $res {
+            local cassandra = require "cassandra"
+            local session = cassandra.spawn_session {
+                shm = "cassandra",
+                contact_points = {"127.0.0.1"}
+            }
+            local rows = session:execute "SELECT key FROM system.local"
+            local socket = session.hosts[1].socket
+
+            ngx.log(ngx.DEBUG, "set "..rows[1].key.." "..tostring(socket.setkeepalive ~= nil))
+            return rows[1].key
+        }
+
+        echo $res;
+    }
+--- request
+GET /t
+--- response_body
+local
+--- error_log eval
+qr/\[debug\].*?set local false/
+
+
+
+=== TEST 4: suppoer in rewrite
+--- http_config eval
+"$t::Utils::HttpConfig"
+--- config
+    location /t {
+        set $res "";
+        rewrite_by_lua_block {
+            local cassandra = require "cassandra"
+            local session = cassandra.spawn_session {
+                shm = "cassandra",
+                contact_points = {"127.0.0.1"}
+            }
+            local rows = session:execute "SELECT key FROM system.local"
+            local socket = session.hosts[1].socket
+
+            ngx.var.res = rows[1].key
+            ngx.log(ngx.DEBUG, "rewrite "..rows[1].key.." "..tostring(socket.setkeepalive ~= nil))
+        }
+
+        echo $res;
+    }
+--- request
+GET /t
+--- response_body
+local
+--- error_log eval
+qr/\[debug\].*?rewrite local true/
+
+
+
+=== TEST 5: suppoer in access
+--- http_config eval
+"$t::Utils::HttpConfig"
+--- config
+    location /t {
+        access_by_lua_block {
+            local cassandra = require "cassandra"
+            local session = cassandra.spawn_session {
+                shm = "cassandra",
+                contact_points = {"127.0.0.1"}
+            }
+
+            local rows = session:execute "SELECT key FROM system.local"
+            local socket = session.hosts[1].socket
+
+            ngx.say(rows[1].key)
+            ngx.log(ngx.DEBUG, "access "..rows[1].key.." "..tostring(socket.setkeepalive ~= nil))
+        }
+    }
+--- request
+GET /t
+--- response_body
+local
+--- error_log eval
+qr/\[debug\].*?access local true/
+
+
+
+=== TEST 6: suppoer in content
+--- http_config eval
+"$t::Utils::HttpConfig"
+--- config
+    location /t {
+        content_by_lua_block {
+            local cassandra = require "cassandra"
+            local session = cassandra.spawn_session {
+                shm = "cassandra",
+                contact_points = {"127.0.0.1"}
+            }
+
+            local rows = session:execute "SELECT key FROM system.local"
+            local socket = session.hosts[1].socket
+
+            ngx.log(ngx.DEBUG, "content "..rows[1].key.." "..tostring(socket.setkeepalive ~= nil))
+        }
+    }
+--- request
+GET /t
+--- response_body
+
+--- error_log eval
+qr/\[debug\].*?content local true/
+
+
+
+=== TEST 7: suppoer in header_filter
+--- http_config eval
+"$t::Utils::HttpConfig"
+--- config
+    location /t {
+        return 200;
+
+        header_filter_by_lua_block {
+            local cassandra = require "cassandra"
+            local session = cassandra.spawn_session {
+                shm = "cassandra",
+                contact_points = {"127.0.0.1"}
+            }
+
+            local rows = session:execute "SELECT key FROM system.local"
+            local socket = session.hosts[1].socket
+
+            ngx.log(ngx.DEBUG, "header_filter "..rows[1].key.." "..tostring(socket.setkeepalive ~= nil))
+        }
+    }
+--- request
+GET /t
+--- response_body
+
+--- error_log eval
+qr/\[debug\].*?header_filter local false/
+
+
+
+=== TEST 8: suppoer in body_filter
+--- http_config eval
+"$t::Utils::HttpConfig"
+--- config
+    location /t {
+        return 200;
+
+        body_filter_by_lua_block {
+            local cassandra = require "cassandra"
+            local session = cassandra.spawn_session {
+                shm = "cassandra",
+                contact_points = {"127.0.0.1"}
+            }
+
+            local rows = session:execute "SELECT key FROM system.local"
+            local socket = session.hosts[1].socket
+
+            ngx.log(ngx.DEBUG, "body_filter "..rows[1].key.." "..tostring(socket.setkeepalive ~= nil))
+        }
+    }
+--- request
+GET /t
+--- response_body
+
+--- error_log eval
+qr/\[debug\].*?body_filter local false/
+
+
+
+=== TEST 9: suppoer in log
+--- http_config eval
+"$t::Utils::HttpConfig"
+--- config
+    location /t {
+        return 200;
+
+        log_by_lua_block {
+            local cassandra = require "cassandra"
+            local session = cassandra.spawn_session {
+                shm = "cassandra",
+                contact_points = {"127.0.0.1"}
+            }
+
+            local rows = session:execute "SELECT key FROM system.local"
+            local socket = session.hosts[1].socket
+
+            ngx.log(ngx.DEBUG, "log "..rows[1].key.." "..tostring(socket.setkeepalive ~= nil))
+        }
+    }
+--- request
+GET /t
+--- response_body
+
+--- error_log eval
+qr/\[debug\].*?log local false/
+
+
+
+=== TEST 10: suppoer in timer
+--- http_config eval
+"$t::Utils::HttpConfig"
+--- config
+    location /t {
+        return 200;
+
+        log_by_lua_block {
+            ngx.timer.at(0, function()
+                local cassandra = require "cassandra"
+                local session = cassandra.spawn_session {
+                    shm = "cassandra",
+                    contact_points = {"127.0.0.1"}
+                }
+
+                local rows = session:execute "SELECT key FROM system.local"
+                local socket = session.hosts[1].socket
+
+                ngx.log(ngx.DEBUG, "timer "..rows[1].key.." "..tostring(socket.setkeepalive ~= nil))
+            end)
+        }
+    }
+--- request
+GET /t
+--- response_body
+
+--- error_log eval
+qr/\[debug\].*?timer local true/
+
+
+
+=== TEST 11: luasocket fallback in non-supported contexts only
+--- http_config eval
+"$t::Utils::HttpConfig
+lua_shared_dict test 128k;
+init_by_lua_block {
+    local dict = ngx.shared.test
+    local cassandra = require 'cassandra'
+    local session = cassandra.spawn_session {
+        shm = 'cassandra',
+        contact_points = {'127.0.0.1'}
+    }
+
+    local rows = session:execute 'SELECT key FROM system.local'
+    local socket = session.hosts[1].socket
+    dict:set('cosocket', socket.setkeepalive ~= nil)
+}
+"
+--- config
+    location /t {
+        content_by_lua_block {
+            local cassandra = require 'cassandra'
+            local dict = ngx.shared.test
+
+            local session = cassandra.spawn_session {
+                shm = "cassandra"
+            }
+
+            local rows = session:execute "SELECT key FROM system.local"
+            local socket = session.hosts[1].socket
+
+            ngx.say(dict:get("cosocket"))
+            ngx.say(socket.setkeepalive ~= nil)
+        }
+    }
+--- request
+GET /t
+--- response_body
+false
+true
+--- no_error_log
+[error]
+
+
+
+=== TEST 12: luasocket fallback in non-supported contexts only (bis)
+--- http_config eval
+"$t::Utils::HttpConfig
+lua_shared_dict test 128k;
+init_worker_by_lua_block {
+    local dict = ngx.shared.test
+    local cassandra = require 'cassandra'
+    local session = cassandra.spawn_session {
+        shm = 'cassandra',
+        contact_points = {'127.0.0.1'}
+    }
+
+    local rows = session:execute 'SELECT key FROM system.local'
+    local socket = session.hosts[1].socket
+    dict:set('cosocket', socket.setkeepalive ~= nil)
+}
+"
+--- config
+    location /t {
+        access_by_lua_block {
+            local cassandra = require 'cassandra'
+            local dict = ngx.shared.test
+
+            local session = cassandra.spawn_session {
+                shm = "cassandra"
+            }
+
+            local rows = session:execute "SELECT key FROM system.local"
+            local socket = session.hosts[1].socket
+
+            ngx.say(dict:get("cosocket"))
+            ngx.say(socket.setkeepalive ~= nil)
+        }
+    }
+--- request
+GET /t
+--- response_body
+false
+true
+--- no_error_log
+[error]

--- a/t/99-error-handling.t
+++ b/t/99-error-handling.t
@@ -3,7 +3,7 @@ use t::Utils;
 
 repeat_each(2);
 
-plan tests => repeat_each() * blocks() * 3 + 4;
+plan tests => repeat_each() * (blocks() * 3 + 2);
 
 run_tests();
 
@@ -31,7 +31,7 @@ __DATA__
         end
 
         -- erase hosts from the cache
-        dict:delete("hosts")
+        dict:delete "hosts"
 
         local hosts, err = cache.get_hosts(shm)
         if err then

--- a/util/prove_ccm.sh
+++ b/util/prove_ccm.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 CASSANDRA=${1:-2.2.4}
-echo $CASSANDRA
+
 ccm stop
-ccm create resty_tests -v binary:$CASSANDRA -n 1
+ccm create lua_cassandra_prove -v binary:$CASSANDRA -n 1
+ccm switch lua_cassandra_prove
 ccm start --wait-for-binary-proto


### PR DESCRIPTION
- use lua-resty-socket for LuaSocket fallback
- new t/context.t integration test suite