### PR TITLE
perf(execute) avoid expensive loops on options

### DIFF
--- a/spec/01-unit/options_spec.lua
+++ b/spec/01-unit/options_spec.lua
@@ -16,13 +16,13 @@ describe("options parsing", function()
     end)
     it("should require contact_points", function()
       local err = select(2, parse_cluster({shm = "test"}))
-      assert.equal("contact_points option is required", err)
+      assert.equal("contact_points must be a table", err)
+
+      err = select(2, parse_cluster({shm = "test", contact_points = ""}))
+      assert.equal("contact_points must be a table", err)
 
       err = select(2, parse_cluster({shm = "test", contact_points = {}}))
       assert.equal("contact_points must contain at least one contact point", err)
-
-      err = select(2, parse_cluster({shm = "test", contact_points = {foo = "bar"}}))
-      assert.equal("contact_points must be an array (integer-indexed table)", err)
     end)
     it("should ignore `keyspace` if given", function()
       local options, err = parse_cluster {
@@ -176,6 +176,48 @@ describe("options parsing", function()
       assert.truthy(err)
       assert.equal("auth provider must implement initial_response()", err)
       assert.falsy(options)
+    end)
+  end)
+
+  describe("extend_query_options()", function()
+    local options = parse_session {
+      shm = "test",
+      keyspace = "my_keyspace",
+      contact_points = {"127.0.0.1", "127.0.0.2"}
+    }
+
+    it("override provided options", function()
+      local query_options = options:extend_query_options {page_size = 1000, prepare = true}
+      assert.same({
+        auto_paging = false,
+        consistency = 1,
+        page_size = 1000,
+        prepare = true,
+        retry_on_timeout = true,
+        serial_consistency = 8
+      }, query_options)
+    end)
+    it("higher level override priority", function()
+      local query_options = options:extend_query_options({page_size = 1000, prepare = true}, {page_size = 10})
+      assert.same({
+        auto_paging = false,
+        consistency = 1,
+        page_size = 10,
+        prepare = false,
+        retry_on_timeout = true,
+        serial_consistency = 8
+      }, query_options)
+    end)
+    it("is not confused by booleans", function()
+      local query_options = options:extend_query_options({retry_on_timeout = false})
+      assert.same({
+        auto_paging = false,
+        consistency = 1,
+        page_size = 1000,
+        prepare = false,
+        retry_on_timeout = false,
+        serial_consistency = 8
+      }, query_options)
     end)
   end)
 end)

--- a/spec/01-unit/utils_spec.lua
+++ b/spec/01-unit/utils_spec.lua
@@ -1,75 +1,15 @@
 local table_utils = require "cassandra.utils.table"
 
 describe("table_utils", function()
-  describe("extend_table", function()
-    it("should extend a table from a source", function()
-      local source = {source = true}
-      local target = {target = true}
-
-      target = table_utils.extend_table(source, target)
-      assert.True(target.target)
-      assert.True(target.source)
-    end)
-    it("should extend a table from multiple sources", function()
-      local source1 = {source1 = true}
-      local source2 = {source2 = true}
-      local target = {target = true}
-
-      target = table_utils.extend_table(source1, source2, target)
-      assert.True(target.target)
-      assert.True(target.source1)
-      assert.True(target.source2)
-    end)
-    it("should extend nested properties", function()
-      local source1 = {source1 = true, source1_nested = {hello = "world"}}
-      local source2 = {source2 = true, source2_nested = {hello = "world"}}
-      local target = {target = true}
-
-      target = table_utils.extend_table(source1, source2, target)
-      assert.True(target.target)
-      assert.True(target.source1)
-      assert.True(target.source2)
-      assert.truthy(target.source1_nested)
-      assert.truthy(target.source1_nested.hello)
-      assert.equal("world", target.source1_nested.hello)
-      assert.truthy(target.source2_nested)
-      assert.truthy(target.source2_nested.hello)
-      assert.equal("world", target.source2_nested.hello)
-    end)
-    it("should not override properties in the target", function()
-      local source = {source = true}
-      local target = {target = true, source = "source"}
-
-      target = table_utils.extend_table(source, target)
-      assert.True(target.target)
-      assert.equal("source", target.source)
-    end)
-    it("should not override nested properties in the target", function()
-      local source = {source = true, source_nested = {hello = "world"}}
-      local target = {target = true, source_nested = {hello = "universe"}}
-
-      target = table_utils.extend_table(source, target)
-      assert.True(target.target)
-      assert.truthy(target.source_nested)
-      assert.truthy(target.source_nested.hello)
-      assert.equal("universe", target.source_nested.hello)
-    end)
-    it("should not be mistaken by a `false` value", function()
-      local source = {source = true}
-      local target = {source = false}
-
-      target = table_utils.extend_table(source, target)
-      assert.False(target.source)
-    end)
-    it("should ignore targets that are not tables", function()
-      local source = {foo = {bar = "foobar"}}
-      local target = {foo = "hello"}
-
-      assert.has_no_error(function()
-        target = table_utils.extend_table(source, target)
-      end)
-
-      assert.equal("hello", target.foo)
+  describe("is_array()", function()
+    it("detects arrays", function()
+      assert.True(table_utils.is_array {"a", "b", "c", "d"})
+      assert.True(table_utils.is_array {["1"] = "a", ["2"] = "b", ["3"] = "c", ["4"] = "d"})
+      assert.False(table_utils.is_array {"a", "b", "c", foo = "d"})
+      assert.False(table_utils.is_array())
+      assert.False(table_utils.is_array(false))
+      assert.False(table_utils.is_array(true))
+      assert.False(table_utils.is_array "")
     end)
   end)
 end)

--- a/src/cassandra/options.lua
+++ b/src/cassandra/options.lua
@@ -1,6 +1,25 @@
 local types = require "cassandra.types"
-local utils = require "cassandra.utils.table"
+local remove = table.remove
+local pairs = pairs
 local type = type
+
+local function extend_table(...)
+  local sources = {...}
+  local values = remove(sources)
+
+  for _, source in ipairs(sources) do
+    for k in pairs(source) do
+      if values[k] == nil then
+        values[k] = source[k]
+      end
+      if type(source[k]) == "table" and type(values[k]) == "table" then
+        extend_table(source[k], values[k])
+      end
+    end
+  end
+
+  return values
+end
 
 --- Defaults
 -- @section defaults
@@ -14,8 +33,8 @@ local DEFAULTS = {
   policies = {
     address_resolution = require "cassandra.policies.address_resolution",
     load_balancing = require("cassandra.policies.load_balancing").SharedRoundRobin,
+    reconnection = require("cassandra.policies.reconnection").SharedExponential(1000, 10 * 60 * 1000),
     retry = require("cassandra.policies.retry"),
-    reconnection = require("cassandra.policies.reconnection").SharedExponential(1000, 10 * 60 * 1000)
   },
   query_options = {
     consistency = types.consistencies.one,
@@ -46,9 +65,16 @@ local DEFAULTS = {
   -- auth = nil
 }
 
+local opts_mt = {}
+opts_mt.__index = opts_mt
+
+function opts_mt:extend_query_options(...)
+  return extend_table(self.query_options, ...)
+end
+
 local function parse_session(options, lvl)
   if options == nil then options = {} end
-  utils.extend_table(DEFAULTS, options)
+  extend_table(DEFAULTS, options)
 
   -- keyspace
 
@@ -61,23 +87,18 @@ local function parse_session(options, lvl)
   if options.shm == nil then
     return nil, "shm is required for spawning a cluster/session"
   end
-
   if type(options.shm) ~= "string" then
     return nil, "shm must be a string"
   end
-
   if options.shm == "" then
     return nil, "shm must be a valid string"
   end
-
   if options.prepared_shm == nil then
     options.prepared_shm = options.shm
   end
-
   if type(options.prepared_shm) ~= "string" then
     return nil, "prepared_shm must be a string"
   end
-
   if options.prepared_shm == "" then
     return nil, "prepared_shm must be a valid string"
   end
@@ -87,7 +108,6 @@ local function parse_session(options, lvl)
   if type(options.protocol_options.default_port) ~= "number" then
     return nil, "protocol default_port must be a number"
   end
-
   if type(options.protocol_options.max_schema_consensus_wait) ~= "number" then
     return nil, "protocol max_schema_consensus_wait must be a number"
   end
@@ -109,19 +129,15 @@ local function parse_session(options, lvl)
   if type(options.socket_options) ~= "table" then
     return nil, "socket_options must be a table"
   end
-
   if type(options.socket_options.connect_timeout) ~= "number" then
     return nil, "socket connect_timeout must be a number"
   end
-
   if type(options.socket_options.read_timeout) ~= "number" then
     return nil, "socket read_timeout must be a number"
   end
-
   if options.socket_options.pool_timeout ~= nil and type(options.socket_options.pool_timeout) ~= "number" then
     return nil, "socket pool_timeout must be a number"
   end
-
   if options.socket_options.pool_size ~= nil and type(options.socket_options.pool_size) ~= "number" then
     return nil, "socket pool_size must be a number"
   end
@@ -131,7 +147,6 @@ local function parse_session(options, lvl)
   if type(options.ssl_options) ~= "table" then
     return nil, "ssl_options must be a table"
   end
-
   if type(options.ssl_options.enabled) ~= "boolean" then
     return nil, "ssl_options.enabled must be a boolean"
   end
@@ -146,7 +161,7 @@ local function parse_session(options, lvl)
     end
   end
 
-  return options
+  return setmetatable(options, opts_mt)
 end
 
 local function parse_cluster(options)
@@ -157,18 +172,9 @@ local function parse_cluster(options)
     return nil, err
   end
 
-  if options.contact_points == nil then
-    return nil, "contact_points option is required"
-  end
-
   if type(options.contact_points) ~= "table" then
     return nil, "contact_points must be a table"
   end
-
-  if not utils.is_array(options.contact_points) then
-    return nil, "contact_points must be an array (integer-indexed table)"
-  end
-
   if #options.contact_points < 1 then
     return nil, "contact_points must contain at least one contact point"
   end

--- a/src/cassandra/utils/table.lua
+++ b/src/cassandra/utils/table.lua
@@ -1,47 +1,19 @@
-local table_remove = table.remove
 local tostring = tostring
-local ipairs = ipairs
 local pairs = pairs
 local type = type
 
 local _M = {}
 
-function _M.extend_table(...)
-  local sources = {...}
-  local values = table_remove(sources)
-
-  for _, source in ipairs(sources) do
-    for k in pairs(source) do
-      if values[k] == nil then
-        values[k] = source[k]
-      end
-      if type(source[k]) == "table" and type(values[k]) == "table" then
-        _M.extend_table(source[k], values[k])
-      end
-    end
-  end
-
-  return values
-end
-
-function _M.copy_args(orig)
-  local copy
-  if type(orig) == "table" then
-    copy = {}
-    for orig_key, orig_value in pairs(orig) do
-      copy[_M.copy_args(orig_key)] = _M.copy_args(orig_value)
-    end
-  else
-    copy = orig
-  end
-  return copy
-end
-
 function _M.is_array(t)
+  if type(t) ~= "table" then
+    return false
+  end
   local i = 0
   for _ in pairs(t) do
     i = i + 1
-    if t[i] == nil and t[tostring(i)] == nil then return false end
+    if t[i] == nil and t[tostring(i)] == nil then
+      return false
+    end
   end
   return true
 end


### PR DESCRIPTION
- avoid unnecessary loops on query_options
- provide a method to extend a session's query_options with the argument given to
  execute()
- avoid unnecessary loops on contact_point when validating options. This
  means we don't check if the array is indexed with positive integers
  anymore in favor of performance.