### PR TITLE
fix(cluster) using default_port for peers addresses

### DIFF
--- a/src/cassandra.lua
+++ b/src/cassandra.lua
@@ -1136,7 +1136,7 @@ function Cassandra.refresh_hosts(options)
     end
 
     for _, row in ipairs(rows) do
-      local address = options.policies.address_resolution(row["rpc_address"])
+      local address = options.policies.address_resolution(row["rpc_address"], options.protocol_options.default_port)
       log.info("Adding host "..address)
       hosts[address] = {
         unhealthy_at = 0,


### PR DESCRIPTION
Clusters with nodes not running on the default `9042` port couldn't be
properly reached. Thanks @allisthere2love for the investigation.

This issue was never encountered before and my guess is because such
clusters added their contact_points including the port (`x.x.x.x:9043`),
and the driver could connect to it, but not to the other nodes, since it
was trying `9042` on those. So it simply considered the other nodes as
DOWN, and thus still works (if one doesn't check the logs and those lags
are not displaying warnings, it seems like nothing is going wrong).
However @allisthere2love had nodes from another C* cluster listening on
`9042`, leading to inconsistencies and thus, actual errors that allowed
us to track it down.

As per other datastax drivers, all nodes of a cluster must listen on the
same port.

Fix thibaultCha/lua-cassandra#47
See Mashape/kong#1139