### PR TITLE
feat(cluster) better support for keyspace settings

### DIFF
--- a/lib/cassandra/init.lua
+++ b/lib/cassandra/init.lua
@@ -383,6 +383,7 @@ end
 _Host.get_request_opts = get_opts
 
 local function page_iterator(self, query, args, opts)
+  opts = opts or {}
   local page = 0
   return function(_, p_rows)
     local meta = p_rows.meta

--- a/lib/cassandra/init.lua
+++ b/lib/cassandra/init.lua
@@ -223,7 +223,7 @@ function _Host:connect()
     if not ok then return nil, err end
   end
 
-  local reused, err = self.sock:getreusedtimes()
+  local reused, err = self:getreusedtimes()
   if not reused then return nil, err end
 
   if reused < 1 then
@@ -263,6 +263,13 @@ function _Host:connect()
   end
 
   return true
+end
+
+function _Host:getreusedtimes(...)
+  if not self.sock then
+    return nil, 'no socket created'
+  end
+  return self.sock:getreusedtimes(...)
 end
 
 --- Set the timeout value.

--- a/lib/resty/cassandra/cluster.lua
+++ b/lib/resty/cassandra/cluster.lua
@@ -108,12 +108,12 @@ local function get_peers(self)
 end
 
 local function set_peer_down(self, host)
-  log(WARN, _log_prefix, 'setting host at ', host.coordinator, ' DOWN')
+  log(WARN, _log_prefix, 'setting host at ', host, ' DOWN')
   return set_peer(self, host, false, self.reconn_policy:next_delay(host), get_now())
 end
 
 local function set_peer_up(self, host)
-  log(NOTICE, _log_prefix, 'setting host at ', host.coordinator, ' UP')
+  log(NOTICE, _log_prefix, 'setting host at ', host, ' UP')
   self.reconn_policy:reset(host)
   return set_peer(self, host, true, 0, 0)
 end

--- a/t/06-cluster.t
+++ b/t/06-cluster.t
@@ -51,6 +51,11 @@ GET /t
             if not cluster then
                 ngx.say(err)
             end
+
+            cluster, err = Cluster.new({keyspace = 123})
+            if not cluster then
+                ngx.say(err)
+            end
         }
     }
 --- request
@@ -59,6 +64,7 @@ GET /t
 opts must be a table
 shm must be a string
 no shared dict invalid_shm
+keyspace must be a string
 --- no_error_log
 [error]
 
@@ -125,7 +131,7 @@ true opt: true
 
 
 
-=== TEST 5: cluster.new() peers opts
+=== TEST 5: cluster.new() peers opts and keyspace
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -143,7 +149,7 @@ true opt: true
                 return
             end
 
-            ngx.say('keyspace: ', cluster.peers_opts.keyspace)
+            ngx.say('keyspace: ', cluster.keyspace)
             ngx.say('ssl: ', cluster.peers_opts.ssl)
             ngx.say('verify: ', cluster.peers_opts.verify)
             ngx.say('auth: ', type(cluster.peers_opts.auth))


### PR DESCRIPTION
* do not set keyspace when spawning a coordinator from the load
balancing policy
* allow to override a cluster's `keyspace` setting from
`execute`/`batch`/`iterate`
* document new `coordinator_options` argument
* add the necessary tests