### PR TITLE
feat(cluster) hosts info stored in shm

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -19,6 +19,7 @@ luarocks install luasocket
 pip install --user PyYAML six
 git clone https://github.com/pcmanus/ccm.git
 pushd ccm
+  git checkout 18a50dfde2069e64a3124e2300ad1f0c1e08f908
   ./setup.py install --user
 popd
 

--- a/lib/cassandra/init.lua
+++ b/lib/cassandra/init.lua
@@ -383,6 +383,7 @@ end
 _Host.get_request_opts = get_opts
 
 local function page_iterator(self, query, args, opts)
+  opts = opts or {}
   local page = 0
   return function(_, p_rows)
     local meta = p_rows.meta

--- a/lib/cassandra/init.lua
+++ b/lib/cassandra/init.lua
@@ -223,7 +223,7 @@ function _Host:connect()
     if not ok then return nil, err end
   end
 
-  local reused, err = self.sock:getreusedtimes()
+  local reused, err = self:getreusedtimes()
   if not reused then return nil, err end
 
   if reused < 1 then
@@ -263,6 +263,13 @@ function _Host:connect()
   end
 
   return true
+end
+
+function _Host:getreusedtimes(...)
+  if not self.sock then
+    return nil, 'no socket created'
+  end
+  return self.sock:getreusedtimes(...)
 end
 
 --- Set the timeout value.

--- a/lib/cassandra/init.lua
+++ b/lib/cassandra/init.lua
@@ -9,6 +9,7 @@ local cql = require 'cassandra.cql'
 
 local setmetatable = setmetatable
 local requests = cql.requests
+local fmt = string.format
 local pairs = pairs
 local find = string.find
 
@@ -215,7 +216,9 @@ function _Host:connect()
     return nil, 'no socket created'
   end
 
-  local ok, err = self.sock:connect(self.host, self.port)
+  local ok, err = self.sock:connect(self.host, self.port, {
+    pool = fmt('%s:%d:%s', self.host, self.port, self.keyspace or '')
+  })
   if not ok then return nil, err, true end
 
   if self.ssl then
@@ -253,10 +256,6 @@ function _Host:connect()
     end
 
     if self.keyspace then
-      -- TODO: since this not sent when the socket was retrieved
-      -- from the connection pool, we must document that manually
-      -- calling set_keyspace() is required if users interact with
-      -- several at once.
       local res, err = self:set_keyspace(self.keyspace)
       if not res then return nil, err end
     end

--- a/lib/cassandra/init.lua
+++ b/lib/cassandra/init.lua
@@ -226,7 +226,7 @@ function _Host:connect()
     if not ok then return nil, err end
   end
 
-  local reused, err = self:getreusedtimes()
+  local reused, err = self.sock:getreusedtimes()
   if not reused then return nil, err end
 
   if reused < 1 then
@@ -256,19 +256,13 @@ function _Host:connect()
     end
 
     if self.keyspace then
-      local res, err = self:set_keyspace(self.keyspace)
+      local keyspace_req = requests.keyspace.new(self.keyspace)
+      local res, err = self:send(keyspace_req)
       if not res then return nil, err end
     end
   end
 
   return true
-end
-
-function _Host:getreusedtimes(...)
-  if not self.sock then
-    return nil, 'no socket created'
-  end
-  return self.sock:getreusedtimes(...)
 end
 
 --- Set the timeout value.
@@ -310,6 +304,27 @@ function _Host:close(...)
     return nil, 'no socket created'
   end
   return self.sock:close(...)
+end
+
+--- Change the client's keyspace.
+-- Closes the current connection and open a new one to the given
+-- keyspace.
+-- The connection is closed and reopen so that we use a different connection
+-- pool for usage in ngx_lua.
+-- @param[type=string] keyspace Name of the desired keyspace.
+-- @treturn boolean `ok`: `true` if success, `nil` if failure.
+-- @treturn string `err`: String describing the error if failure.
+function _Host:change_keyspace(keyspace)
+  local ok, err = self:close()
+  if not ok then return nil, err end
+
+  local sock, err = socket.tcp()
+  if err then return nil, err end
+
+  self.sock = sock
+  self.keyspace = keyspace
+
+  return self:connect()
 end
 
 --- Query options.
@@ -406,17 +421,6 @@ local function page_iterator(self, query, args, opts)
 end
 
 _Host.page_iterator = page_iterator
-
---- Set the client's keyspace.
--- Sends a query to change which keyspace the client is connected to.
--- @param[type=string] keyspace Name of the desired keyspace.
--- @treturn table `res`: Table holding the query result if success, `nil` if failure.
--- @treturn string `err`: String describing the error if failure.
--- @treturn number `cql_err`: If a server-side error occurred, the CQL error code.
-function _Host:set_keyspace(keyspace)
-  local keyspace_req = requests.keyspace.new(keyspace)
-  return self:send(keyspace_req)
-end
 
 --- Prepare a query.
 -- Sends a PREPARE request for the given query. The result of this request will

--- a/lib/resty/cassandra/cluster.lua
+++ b/lib/resty/cassandra/cluster.lua
@@ -61,7 +61,7 @@ local function set_peer(self, host, up, reconn_delay, unhealthy_at,
   -- status
   local ok, err = self.shm:set(host, up)
   if not ok then
-    return nil, 'could not set host details in shm: '..err
+    return nil, 'could not set host status in shm: '..err
   end
 
   -- host health and info
@@ -404,6 +404,7 @@ end
 -- called if further updates are required.
 -- @treturn boolean `ok`: `true` if success, `nil` if failure.
 -- @treturn string `err`: String describing the error if failure.
+-- @treturn table `peers`: A list of peers retrieved from the cluster
 function _Cluster:refresh()
   local old_peers, err = get_peers(self)
   if err then return nil, err
@@ -476,7 +477,7 @@ function _Cluster:refresh()
 
   self.lb_policy:init(peers)
   self.init = true
-  return true
+  return true, nil, peers
 end
 
 --------------------

--- a/lib/resty/cassandra/cluster.lua
+++ b/lib/resty/cassandra/cluster.lua
@@ -425,7 +425,7 @@ function _Cluster:refresh()
 
   local lock = resty_lock:new(self.dict_name)
   local elapsed, err = lock:lock('refresh')
-  if not elapsed then return nil, 'failed to acquire lock: '..err end
+  if not elapsed then return nil, 'failed to acquire refresh lock: '..err end
 
   -- did someone else got the hosts?
   local peers, err = get_peers(self)

--- a/spec/02-integration/01-host_spec.lua
+++ b/spec/02-integration/01-host_spec.lua
@@ -97,6 +97,13 @@ describe("cassandra (host)", function()
       assert.equal("timeout", err)
       assert.True(maybe_down)
     end)
+    it("connects directly in a keyspace", function()
+      local peer_k = assert(cassandra.new {keyspace = "system"})
+      assert(peer_k:connect())
+
+      local rows = assert(peer_k:execute "SELECT * FROM local")
+      assert.equal("local", rows[1].key)
+    end)
   end)
 
   describe("close()", function()
@@ -249,7 +256,7 @@ describe("cassandra (host)", function()
       end)
       describe("protocol v3 options", function()
         setup(function()
-          assert(peer:set_keyspace(helpers.keyspace))
+          assert(peer:change_keyspace(helpers.keyspace))
           assert(peer:execute [[
             CREATE TABLE IF NOT EXISTS options(
               id int PRIMARY KEY,
@@ -344,22 +351,13 @@ describe("cassandra (host)", function()
       end)
     end)
 
-    describe("set_keyspace()", function()
-      it("sets a peer's keyspace", function()
+    describe("change_keyspace()", function()
+      it("changes a peer's keyspace", function()
         local peer_k = assert(cassandra.new())
         assert(peer_k:connect())
 
-        local res = assert(peer_k:set_keyspace "system")
-        assert.equal(0, #res)
-        assert.equal("SET_KEYSPACE", res.type)
-        assert.equal("system", res.keyspace)
-
-        local rows = assert(peer_k:execute "SELECT * FROM local")
-        assert.equal("local", rows[1].key)
-      end)
-      it("connects directly in a keyspace", function()
-        local peer_k = assert(cassandra.new {keyspace = "system"})
-        assert(peer_k:connect())
+        assert(peer_k:change_keyspace "system")
+        assert.equal("system", peer_k.keyspace)
 
         local rows = assert(peer_k:execute "SELECT * FROM local")
         assert.equal("local", rows[1].key)
@@ -368,7 +366,7 @@ describe("cassandra (host)", function()
 
     describe("batch()", function()
       setup(function()
-        assert(peer:set_keyspace(helpers.keyspace))
+        assert(peer:change_keyspace(helpers.keyspace))
         assert(peer:execute [[
           CREATE TABLE IF NOT EXISTS things(
             id uuid PRIMARY KEY,
@@ -531,7 +529,7 @@ describe("cassandra (host)", function()
 
     describe("Types marshalling", function()
       setup(function()
-        assert(peer:set_keyspace(helpers.keyspace))
+        assert(peer:change_keyspace(helpers.keyspace))
         assert(peer:execute [[
           CREATE TYPE IF NOT EXISTS address(
             street text,

--- a/t/06-cluster.t
+++ b/t/06-cluster.t
@@ -323,9 +323,9 @@ GET /t
 --- request
 GET /t
 --- response_body_like
-\d+\.\d+\.\d+\.\d+.*?\S+.*?\d+\.\d+\.?\d?
-\d+\.\d+\.\d+\.\d+.*?\S+.*?\d+\.\d+\.?\d?
-\d+\.\d+\.\d+\.\d+.*?\S+.*?\d+\.\d+\.?\d?
+\d+\.\d+\.\d+\.\d+.*?\S+.*?\d+\.\d+\.?\d*
+\d+\.\d+\.\d+\.\d+.*?\S+.*?\d+\.\d+\.?\d*
+\d+\.\d+\.\d+\.\d+.*?\S+.*?\d+\.\d+\.?\d*
 --- no_error_log
 [error]
 
@@ -620,12 +620,12 @@ GET /t
 --- request
 GET /t
 --- response_body_like
-127\.0\.0\.3 after down: datacenter1 \d+\.\d+\.?\d?
-127\.0\.0\.3 after up: datacenter1 \d+\.\d+\.?\d?
-127\.0\.0\.2 after down: datacenter1 \d+\.\d+\.?\d?
-127\.0\.0\.2 after up: datacenter1 \d+\.\d+\.?\d?
-127\.0\.0\.1 after down: datacenter1 \d+\.\d+\.?\d?
-127\.0\.0\.1 after up: datacenter1 \d+\.\d+\.?\d?
+127\.0\.0\.3 after down: datacenter1 \d+\.\d+\.?\d*
+127\.0\.0\.3 after up: datacenter1 \d+\.\d+\.?\d*
+127\.0\.0\.2 after down: datacenter1 \d+\.\d+\.?\d*
+127\.0\.0\.2 after up: datacenter1 \d+\.\d+\.?\d*
+127\.0\.0\.1 after down: datacenter1 \d+\.\d+\.?\d*
+127\.0\.0\.1 after up: datacenter1 \d+\.\d+\.?\d*
 --- no_error_log
 [error]
 

--- a/t/06-cluster.t
+++ b/t/06-cluster.t
@@ -1128,3 +1128,39 @@ GET /t
 127.0.0.1 is back up: true
 --- no_error_log
 [error]
+
+
+
+=== TEST 25: next_coordinator() sets coordinator keyspace on connect
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local Cluster = require 'resty.cassandra.cluster'
+            local cluster, err = Cluster.new()
+            if not cluster then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local ok, err = cluster:refresh()
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local coordinator, err = cluster:next_coordinator('system')
+            if not coordinator then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            ngx.say(coordinator.keyspace)
+        }
+    }
+--- request
+GET /t
+--- response_body
+system
+--- no_error_log
+[error]

--- a/t/06-cluster.t
+++ b/t/06-cluster.t
@@ -500,7 +500,37 @@ corrupted shm
 
 
 
-=== TEST 14: set_peer_down()/set_peer_up()/can_try_peer() set shm booleans for nodes status
+=== TEST 14: get_peers() returns nil if no peers
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local Cluster = require 'resty.cassandra.cluster'
+            local cluster, err = Cluster.new()
+            if not cluster then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local peers, err = cluster:get_peers()
+            if err then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            ngx.say('is nil: ', peers == nil)
+        }
+    }
+--- request
+GET /t
+--- response_body
+is nil: true
+--- no_error_log
+[error]
+
+
+
+=== TEST 15: set_peer_down()/set_peer_up()/can_try_peer() set shm booleans for nodes status
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -562,7 +592,7 @@ GET /t
 
 
 
-=== TEST 15: set_peer_down()/set_peer_up() use existing host details if exists
+=== TEST 16: set_peer_down()/set_peer_up() use existing host details if exists
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -631,7 +661,7 @@ GET /t
 
 
 
-=== TEST 16: set_peer_down()/set_peer_up() defaults hosts details if not exists
+=== TEST 17: set_peer_down()/set_peer_up() defaults hosts details if not exists
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -690,7 +720,7 @@ GET /t
 
 
 
-=== TEST 17: set_peer_down()/set_peer_up() use reconnection policy (update peer_rec delays)
+=== TEST 18: set_peer_down()/set_peer_up() use reconnection policy (update peer_rec delays)
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -776,7 +806,7 @@ reconn_delay: true
 
 
 
-=== TEST 18: can_try_peer() use reconnection policy to decide when node is down
+=== TEST 19: can_try_peer() use reconnection policy to decide when node is down
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -840,7 +870,7 @@ after delay: true true
 
 
 
-=== TEST 19: next_coordinator() uses load balancing policy
+=== TEST 20: next_coordinator() uses load balancing policy
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -877,7 +907,7 @@ coordinator 3: 127.0.0.1
 
 
 
-=== TEST 20: next_coordinator() returns no host available errors
+=== TEST 21: next_coordinator() returns no host available errors
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -921,7 +951,7 @@ all hosts tried for query failed. 127.0.0.2: host still considered down. 127.0.0
 
 
 
-=== TEST 21: next_coordinator() avoids down hosts
+=== TEST 22: next_coordinator() avoids down hosts
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -965,7 +995,7 @@ GET /t
 
 
 
-=== TEST 22: next_coordinator() marks nodes as down
+=== TEST 23: next_coordinator() marks nodes as down
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -1029,7 +1059,7 @@ can try peer 255.255.255.253: false
 
 
 
-=== TEST 23: next_coordinator() retries down host as per reconnection policy and ups them back
+=== TEST 24: next_coordinator() retries down host as per reconnection policy and ups them back
 --- http_config eval: $::HttpConfig
 --- config
     location /t {

--- a/t/06-cluster.t
+++ b/t/06-cluster.t
@@ -51,6 +51,11 @@ GET /t
             if not cluster then
                 ngx.say(err)
             end
+
+            cluster, err = Cluster.new({keyspace = 123})
+            if not cluster then
+                ngx.say(err)
+            end
         }
     }
 --- request
@@ -59,6 +64,7 @@ GET /t
 opts must be a table
 shm must be a string
 no shared dict invalid_shm
+keyspace must be a string
 --- no_error_log
 [error]
 
@@ -125,7 +131,7 @@ true opt: true
 
 
 
-=== TEST 5: cluster.new() peers opts
+=== TEST 5: cluster.new() peers opts and keyspace
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -143,7 +149,7 @@ true opt: true
                 return
             end
 
-            ngx.say('keyspace: ', cluster.peers_opts.keyspace)
+            ngx.say('keyspace: ', cluster.keyspace)
             ngx.say('ssl: ', cluster.peers_opts.ssl)
             ngx.say('verify: ', cluster.peers_opts.verify)
             ngx.say('auth: ', type(cluster.peers_opts.auth))

--- a/t/06-cluster.t
+++ b/t/06-cluster.t
@@ -419,7 +419,41 @@ info: no host details for 127.0.0.254
 
 
 
-=== TEST 11: cluster.refresh() does not alter existing peers records and status
+=== TEST 12: cluster.refresh() peers in 3rd return value
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local Cluster = require 'resty.cassandra.cluster'
+            local cluster, err = Cluster.new()
+            if not cluster then
+                ngx.log(ngx.ERR, err)
+            end
+
+            local ok, err, peers = cluster:refresh()
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            for i = 1, #peers do
+                local p = peers[i]
+                ngx.say(p.host, ' ', p.up)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+127.0.0.3 true
+127.0.0.2 true
+127.0.0.1 true
+--- no_error_log
+[error]
+
+
+
+=== TEST 13: cluster.refresh() does not alter existing peers records and status
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -712,7 +746,7 @@ after delay: true true
 
 
 
-=== TEST 16: next_coordinator() uses load balancing policy
+=== TEST 18: next_coordinator() uses load balancing policy
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -749,7 +783,7 @@ coordinator 3: 127.0.0.1
 
 
 
-=== TEST 17: next_coordinator() returns no host available errors
+=== TEST 19: next_coordinator() returns no host available errors
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -793,7 +827,7 @@ all hosts tried for query failed. 127.0.0.2: host still considered down. 127.0.0
 
 
 
-=== TEST 18: next_coordinator() avoids down hosts
+=== TEST 20: next_coordinator() avoids down hosts
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -837,7 +871,7 @@ GET /t
 
 
 
-=== TEST 19: next_coordinator() marks nodes as down
+=== TEST 21: next_coordinator() marks nodes as down
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -901,7 +935,7 @@ can try peer 255.255.255.253: false
 
 
 
-=== TEST 20: next_coordinator() retries down host as per reconnection policy and ups them back
+=== TEST 22: next_coordinator() retries down host as per reconnection policy and ups them back
 --- http_config eval: $::HttpConfig
 --- config
     location /t {

--- a/util/prove_ccm.sh
+++ b/util/prove_ccm.sh
@@ -3,6 +3,8 @@
 CASSANDRA=${1}
 
 ccm stop
-ccm create lua_cassandra_prove -v binary:$CASSANDRA -n 3
+if [[ ! $(ccm list | grep lua_cassandra_prove) ]]; then
+  ccm create lua_cassandra_prove -v binary:$CASSANDRA -n 3
+fi
 ccm switch lua_cassandra_prove
 ccm start --wait-for-binary-proto


### PR DESCRIPTION
* allow to override a cluster's `keyspace` setting from
`execute`/`batch`/`iterate`
* pool connections by `host:port:keyspace`
* document new `coordinator_options` argument
* add the necessary tests
* store `data_center` and `release_version` in the shm.