### PR TITLE
chore(ci) update setup_env script to easily bump deps versions

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -1,17 +1,4 @@
 set -e
-set -x
-
-# -----------
-# Install Lua
-# -----------
-pip install --user hererocks
-hererocks $LUA_DIR -r^ --$LUA
-export PATH=$PATH:$LUA_DIR/bin
-eval `luarocks path`
-
-# init_by_lua + plain Lua dependencies
-luarocks install luasec
-luarocks install luasocket
 
 # -----------
 # Install ccm
@@ -23,37 +10,71 @@ pushd ccm
   ./setup.py install --user
 popd
 
-
 if [ "$OPENRESTY_TESTS" = true ]; then
-  # -----------------
-  # Install OpenResty
-  # -----------------
-  mkdir -p $OPENRESTY_DIR
+  #------------------------------
+  # Download OpenResty + Luarocks
+  #------------------------------
+  OPENRESTY_DOWNLOAD=$DOWNLOAD_CACHE/openresty-$OPENRESTY
+  LUAROCKS_DOWNLOAD=$DOWNLOAD_CACHE/luarocks-$LUAROCKS
 
-  if [ ! "$(ls -A $OPENRESTY_DIR)" ]; then
-    OPENRESTY_BASE=openresty-$OPENRESTY
-    curl https://openresty.org/download/$OPENRESTY_BASE.tar.gz | tar xz
-    pushd $OPENRESTY_BASE
+  mkdir -p $OPENRESTY_DOWNLOAD $LUAROCKS_DOWNLOAD
+
+  if [ ! "$(ls -A $OPENRESTY_DOWNLOAD)" ]; then
+    pushd $DOWNLOAD_CACHE
+      curl -L https://openresty.org/download/openresty-$OPENRESTY.tar.gz | tar xz
+    popd
+  fi
+
+  if [ ! "$(ls -A $LUAROCKS_DOWNLOAD)" ]; then
+    git clone https://github.com/keplerproject/luarocks.git $LUAROCKS_DOWNLOAD
+  fi
+
+  #-----------------------------
+  # Install OpenResty + Luarocks
+  #-----------------------------
+  OPENRESTY_INSTALL=$INSTALL_CACHE/openresty-$OPENRESTY
+  LUAROCKS_INSTALL=$INSTALL_CACHE/luarocks-$LUAROCKS
+
+  mkdir -p $OPENRESTY_INSTALL $LUAROCKS_INSTALL
+
+  if [ ! "$(ls -A $OPENRESTY_INSTALL)" ]; then
+    pushd $OPENRESTY_DOWNLOAD
       ./configure \
-        --prefix=$OPENRESTY_DIR \
+        --prefix=$OPENRESTY_INSTALL \
         --without-http_coolkit_module \
-        --without-lua_resty_dns \
-        --without-lua_resty_lrucache \
-        --without-lua_resty_upstream_healthcheck \
-        --without-lua_resty_websocket \
-        --without-lua_resty_upload \
-        --without-lua_resty_string \
-        --without-lua_resty_mysql \
-        --without-lua_resty_redis \
-        --without-http_redis_module \
-        --without-http_redis2_module \
-        --without-lua_redis_parser
+          --without-http_coolkit_module \
+          --without-lua_resty_dns \
+          --without-lua_resty_lrucache \
+          --without-lua_resty_upstream_healthcheck \
+          --without-lua_resty_websocket \
+          --without-lua_resty_upload \
+          --without-lua_resty_string \
+          --without-lua_resty_mysql \
+          --without-lua_resty_redis \
+          --without-http_redis_module \
+          --without-http_redis2_module \
+          --without-lua_redis_parser
       make
       make install
     popd
   fi
 
-  export PATH=$PATH:$OPENRESTY_DIR/nginx/sbin
+  if [ ! "$(ls -A $LUAROCKS_INSTALL)" ]; then
+    pushd $LUAROCKS_DOWNLOAD
+      git checkout v$LUAROCKS
+      ./configure \
+        --prefix=$LUAROCKS_INSTALL \
+        --lua-suffix=jit \
+        --with-lua=$OPENRESTY_INSTALL/luajit \
+        --with-lua-include=$OPENRESTY_INSTALL/luajit/include/luajit-2.1
+      make build
+      make install
+    popd
+  fi
+
+  export PATH=$PATH:$OPENRESTY_INSTALL/nginx/sbin:$OPENRESTY_INSTALL/bin:$LUAROCKS_INSTALL/bin
+
+  eval `luarocks path`
 
   # -------------------
   # Install Test::Nginx
@@ -61,11 +82,31 @@ if [ "$OPENRESTY_TESTS" = true ]; then
   curl -L https://cpanmin.us | perl - App::cpanminus
   $PERL_DIR/bin/cpanm Test::Nginx::Socket
   $PERL_DIR/bin/cpanm --local-lib=$PERL_DIR local::lib && eval $(perl -I $PERL_DIR/lib/perl5/ -Mlocal::lib)
+
+  nginx -V
+  resty -V
+  prove -V
 else
+  # -----------
+  # Install Lua
+  # -----------
+  LUA_DIR=$HOME/lua
+
+  pip install --user hererocks
+  hererocks $LUA_DIR -r^ --$LUA
+  export PATH=$PATH:$LUA_DIR/bin
+  eval `luarocks path`
+
   # -------------------------
   # Install test dependencies
   # -------------------------
   luarocks install busted
   luarocks install luacheck
-  luarocks install luacov-coveralls
 fi
+
+# init_by_lua + plain Lua dependencies
+luarocks install luasec
+luarocks install luasocket
+luarocks install luacov-coveralls
+
+luarocks --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
+sudo: false
+
 language: java
+
 jdk:
   - oraclejdk8
-sudo: false
+
 notifications:
   email: false
+
 addons:
   apt:
     packages:
@@ -12,35 +16,40 @@ addons:
       - libpcre3-dev
       - libssl-dev
       - build-essential
+
 env:
   global:
-    - OPENRESTY=1.9.15.1
-    - OPENRESTY_DIR=$HOME/openresty
+    - LUAROCKS=2.4.0
+    - OPENRESTY=1.11.2.1
+    - DOWNLOAD_CACHE=$HOME/download-cache
+    - INSTALL_CACHE=$HOME/install-cache
     - PERL_DIR=$HOME/perl5
-    - LUA_DIR=$HOME/lua
   matrix:
     - LUA="lua 5.1"
     - LUA="lua 5.2"
     - LUA="luajit 2.0"
     - LUA="luajit 2.1"
     - OPENRESTY_TESTS=true
-      LUA="luajit 2.1"
     - OPENRESTY_TESTS=true
-      LUA="luajit 2.1"
       CASSANDRA=2.2.7
     - OPENRESTY_TESTS=true
-      LUA="luajit 2.1"
       CASSANDRA=2.1.15
+
 before_install:
   - source .ci/setup_env.sh
+
 install:
   - make install
-script: .ci/run_tests.sh
+
+script:
+  - .ci/run_tests.sh
+
 cache:
   cpan: true
   apt: true
   pip: true
   directories:
     - $PERL_DIR
-    - $OPENRESTY_DIR
+    - $DOWNLOAD_CACHE
+    - $INSTALL_CACHE
     - $HOME/.ccm/repository/


### PR DESCRIPTION
This avoids the need to manually purge the travis cache when bumping a
version dependency.