### PR TITLE
Add support for stream_id

### DIFF
--- a/lib/cassandra/cql.lua
+++ b/lib/cassandra/cql.lua
@@ -945,10 +945,15 @@ do
 
     header:write_byte(flags)
 
+    local stream_id = 0
+    if self.opts and self.opts.stream_id then
+      stream_id = self.opts.stream_id
+    end
+
     if version < 3 then
-      header:write_byte(0)       -- stream_id
+      header:write_byte(stream_id)
     else
-      header:write_short(0)      -- stream_id
+      header:write_short(stream_id)
     end
 
     header:write_byte(self.op_code)

--- a/lib/resty/cassandra/cluster.lua
+++ b/lib/resty/cassandra/cluster.lua
@@ -387,6 +387,7 @@ function _Cluster.new(opts)
                 or require('resty.cassandra.policies.reconnection.exp').new(1000, 60000),
     retry_policy = opts.retry_policy
                 or require('resty.cassandra.policies.retry.simple').new(3),
+    stream_ids = nil,
   }, _Cluster)
 end
 
@@ -549,6 +550,15 @@ function _Cluster:refresh()
 
   -- initiate the load balancing policy
   self.lb_policy:init(peers)
+
+  if self.stream_ids == nil then
+    -- Initialize the list of available seed ids (only once)
+    self.stream_ids = {}
+    local max_id = protocol_version < 3 and 2^7-1 or 2^15-1
+    for i=1,max_id do
+      self.stream_ids[i] = i
+    end
+  end
 
   -- cluster is ready to be queried
   self.init = true
@@ -748,8 +758,45 @@ local function handle_error(self, err, cql_code, coordinator, request)
   return nil, err, cql_code
 end
 
+local function get_stream_id(self)
+  local stream_id = 0
+
+  local lock = resty_lock:new(self.dict_name, self.lock_opts)
+  local elapsed, err = lock:lock('stream_id')
+  if not elapsed then return stream_id, 'failed to acquire stream_id lock: '..err end
+
+  if table.getn(self.stream_ids) > 0 then
+    stream_id = table.remove(self.stream_ids)
+  else
+    err = 'Too many inflight requests. No new stream ids available.'
+  end
+
+  local ok, err = lock:unlock()
+  if not ok then return stream_id, 'failed to unlock: '..err end
+
+  return stream_id, nil
+end
+
+local function release_stream_id(self, stream_id)
+  local lock = resty_lock:new(self.dict_name, self.lock_opts)
+  local elapsed, err = lock:lock('stream_id')
+  if not elapsed then return stream_id, 'failed to acquire stream_id lock: '..err end
+
+  table.insert(self.stream_ids, 1, stream_id)
+
+  local ok, err = lock:unlock()
+  if not ok then return stream_id, 'failed to unlock: '..err end
+end
+
 send_request = function(self, coordinator, request)
+  local err
+  request.opts.stream_id, err = get_stream_id(self)
+  if err ~= nil and self.logging then
+    log(WARN, _log_prefix, err)
+  end
+
   local res, err, cql_code = coordinator:send(request)
+  release_stream_id(self, request.opts.stream_id)
   if not res then
     return handle_error(self, err, cql_code, coordinator, request)
   elseif res.warnings and self.logging then

--- a/spec/01-unit/03-cql_spec.lua
+++ b/spec/01-unit/03-cql_spec.lua
@@ -166,6 +166,7 @@ for protocol_version = 2, 3 do
 
   describe("CQL requests", function()
     local requests = cql.requests
+    local consistencies = cql.consistencies
 
     it("sanity", function()
       local r = requests.query.new("SELECT * FROM peers")
@@ -189,6 +190,14 @@ for protocol_version = 2, 3 do
 
         local frame3 = r:build_frame(protocol_version)
         assert.matches("SELECT key FROM local", frame3, nil, true)
+      end)
+      it("sets the stream_id if provided", function()
+        local r = requests.query.new("SELECT * FROM local")
+        r.opts = {stream_id = 255, consistency = consistencies.one}
+        local frame = r:build_frame(protocol_version)
+
+        local header = cql.frame_reader.read_header(protocol_version, string.sub(frame, 2, -1))
+        assert.equal(255, header.stream_id)
       end)
     end)
 


### PR DESCRIPTION
2 main changes:
- allow setting an optional stream_id in the request
- if stream_id is set, all responses with a different id will be dropped

The issue we're hitting right now is that we set a low timeout (increasing it is not an option), which makes some of our queries timeout. AFAICT there's the possibility of a race condition where the first client times out, immediately after a second client sends a different request using the same connection and ends up reading the old response for client1. The way to avoid this is to set and verify the stream_id and ignore any non-matching message.

------
NOTES

The logic to assign an id to a request has to be protected with a mutex to avoid 2 requests ending up with the same id. Since the code outside `lib/resty/cassandra` cannot depend on openresty packages, I had to generate the id in `cluster.lua` and propagate it to `lib/cassandra/cql.lua:build_frame`.

The response read code in `lib/cassandra/init.lua:send` is now inside an infinite loop. We'll keep reading until we find a response with the right id. Or until the timeout expires.

`lib/cassandra/init.lua` and `lib/resty/cassandra` are not unit tested at all, so I haven't added any new test for my change.

Also the integration tests fail on my macbook: cassandra refuses to start with `Can not set double field org.apache.cassandra.config.Config.commitlog_sync_batch_window_in_ms to null value`.
I'll let travis run them.