### PR TITLE
Fix 01-rockspec tests

### DIFF
--- a/spec/01-unit/01-rockspec_spec.lua
+++ b/spec/01-unit/01-rockspec_spec.lua
@@ -43,7 +43,8 @@ describe("rockspec", function()
     end
 
     rock_filenames = exec("find . -name 'lua-cassandra-*.rockspec'")
-    local rock_filename, dev_rock_filename = rock_filenames:match("(%S.*%S)\n(%S.*%S)")
+    local rock_filename = rock_filenames:match("(lua%-cassandra%-[%d%.-]*.rockspec)")
+    local dev_rock_filename = rock_filenames:match("(lua%-cassandra%-dev%-[%d-]*.rockspec)")
 
     local f = assert(loadfile(rock_filename))
     _setfenv(f, rocks.production)


### PR DESCRIPTION
These tests assume the 'find *.rockspec' command will return the 2
rockspec files in a specific order (first the prod one and then dev).

This is not always true. It might depend on the OS, find implementation
or something else, I don't know. But we can't assume any order.

So I've changed the code so that it'll now try to match the filenames.