### PR TITLE
Allow installing rocks locally - fix openssl include

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,26 @@ The documentation is generated with
 $ make doc
 ```
 
+#### macOS notes
+
+## Openssl headers
+
+Newer versions of macOS don't include the openssl headers by purpose. You'll need to install
+them via `brew install openssl` or manually.
+
+Homebrew openssl headers however don't get symlinked in /usr/local, so you need to tell
+luarocks where to find them via `OPENSSL_DIR`.
+
+```
+OPENSSL_DIR=/usr/local/opt/openssl/ FLAGS='--local' make busted
+```
+
+## Install rocks locally
+
+To install the development dependencies locally instead of in `/usr/local`, set
+`FLAGS='--local'`. This will use the tree in the user's home directory.
+You might also need to run `eval $(luarocks path --bin)` to add them to your path.
+
 [Back to TOC](#table-of-contents)
 
 [Luarocks]: https://luarocks.org

--- a/lua-cassandra-1.2.3-0.rockspec
+++ b/lua-cassandra-1.2.3-0.rockspec
@@ -10,7 +10,9 @@ description = {
   license = "MIT"
 }
 dependencies = {
-  "luabitop"
+  "luabitop",
+  "luasec",
+  "luasocket"
 }
 build = {
   type = "builtin",

--- a/lua-cassandra-dev-0.rockspec
+++ b/lua-cassandra-dev-0.rockspec
@@ -9,7 +9,9 @@ description = {
   license = "MIT"
 }
 dependencies = {
-  "luabitop"
+  "luabitop",
+  "luasec",
+  "luasocket"
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
/usr/local is not writable on my machine by purpose, so `make dev` fails
with permission error. I've changed the Makefile to allow installing
rocks in the user's home directory. This is optional, so by default `make
dev` will have the same behaviour as now.

I'm not super happy with this solution either, imo the right thing would
be to create a local tree inside this directory and install the
dependencies there instead of polluting the system. That's possible and
it works, however it required me to set the lua load paths in several
places and wasn't "backward compatible", so I chose to go with this
solution for now which should be easier to code-review.

Another issue that I encountered is that openssl header files on macOS
are not inside `/usr/local`, which mean I couldn't install luasec. To
fix this I've added an optional OPENSSL_DIR env variable that can be
used to configure luarocks. (This is the suggested procedure on luasec's
website).

I've also added luasec and luasocket as lua-cassandra dependencies since
without them the tests break. There doesn't seem to be a way to mark
luasec as optional (since it's only require if you enable ssl)
unfortunately.