### PR TITLE
Upgrade ccm to 3.0.1

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -6,7 +6,8 @@ set -e
 pip install --user PyYAML six
 git clone https://github.com/pcmanus/ccm.git
 pushd ccm
-  git checkout 18a50dfde2069e64a3124e2300ad1f0c1e08f908
+  # Version 3.0.1
+  git checkout 599e2026035e334dbc2ce24117ce745641506374
   ./setup.py install --user
 popd
 


### PR DESCRIPTION
Trying to fix the failing integration tests. I don't know if this will
make a difference but it doesn't hurt to try.

They all pass on my laptop with ccm==3.0.1, but the only way I know to
try in travis is to open a  pull-request.