### PR TITLE
tests(*) upgrade ccm and downgrade C* default version

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -6,7 +6,8 @@ set -e
 pip install --user PyYAML six
 git clone https://github.com/pcmanus/ccm.git
 pushd ccm
-  git checkout 18a50dfde2069e64a3124e2300ad1f0c1e08f908
+  # sha of 'Release 3.0.1'
+  git checkout 599e2026035e334dbc2ce24117ce745641506374
   ./setup.py install --user
 popd
 

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -16,7 +16,7 @@ local function exec(cmd, ignore)
 end
 
 local _M = {
-  cassandra_version = os.getenv("CASSANDRA") or "3.10",
+  cassandra_version = os.getenv("CASSANDRA") or "3.9",
   ssl_path = os.getenv("SSL_PATH") or "spec/fixtures/ssl"
 }
 


### PR DESCRIPTION
- cleaned Travis CI cache
- Bumped ccm to latest `3.0.1`
- Downgraded C* 3.10 default to 3.9 (3.9 is as of today the desired version to tests against as per the travis.yml)