### PR TITLE
fix(lb) allow req-aware lb policies to run in init_by_lua* with resty.core

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -45,7 +45,6 @@ if [ "$OPENRESTY_TESTS" = true ]; then
         --without-http_coolkit_module \
           --without-http_coolkit_module \
           --without-lua_resty_dns \
-          --without-lua_resty_lrucache \
           --without-lua_resty_upstream_healthcheck \
           --without-lua_resty_websocket \
           --without-lua_resty_upload \

--- a/lib/resty/cassandra/policies/lb/req_dc_rr.lua
+++ b/lib/resty/cassandra/policies/lb/req_dc_rr.lua
@@ -17,6 +17,8 @@
 
 local _M = require('resty.cassandra.policies.lb').new_policy('req_and_dc_aware_round_robin')
 
+local past_init
+
 --- Create a request and DC-aware round robin policy.
 -- Instanciates a request and DC-aware round robin policy for
 -- `resty.cassandra.cluster`.
@@ -105,7 +107,12 @@ end
 function _M:iter()
   self.local_tried = 0
   self.remote_tried = 0
-  self.ctx = ngx and ngx.ctx
+
+  if past_init or ngx.get_phase() ~= "init" then
+    self.ctx = ngx and ngx.ctx
+    past_init = true
+  end
+
   self.initial_cassandra_coordinator = self.ctx and self.ctx.cassandra_coordinator
   self.local_idx = (self.start_local_idx % #self.local_peers) + 1
   self.remote_idx = (self.start_remote_idx % #self.remote_peers) + 1

--- a/lib/resty/cassandra/policies/lb/req_rr.lua
+++ b/lib/resty/cassandra/policies/lb/req_rr.lua
@@ -13,6 +13,8 @@
 
 local _rr_lb = require('resty.cassandra.policies.lb').new_policy('req_round_robin')
 
+local past_init
+
 --- Create a request-aware round robin policy.
 -- Instanciates a request-aware round robin policy for `resty.cassandra.cluster`.
 --
@@ -61,8 +63,11 @@ local function next_peer(state, i)
 end
 
 function _rr_lb:iter()
-  print()
-  self.ctx = ngx and ngx.ctx
+  if past_init or ngx.get_phase() ~= "init" then
+    self.ctx = ngx and ngx.ctx
+    past_init = true
+  end
+
   self.initial_cassandra_coordinator = self.ctx and self.ctx.cassandra_coordinator
   self.idx = (self.start_idx % #self.peers) + 1
   self.start_idx = self.start_idx + 1

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -3,6 +3,8 @@ package t::Util;
 use strict;
 use warnings;
 
+use base 'Exporter';
+
 my $TEST_COVERAGE_ENABLED = $ENV{TEST_COVERAGE_ENABLED};
 
 my $LuaCovRunner = '';
@@ -15,12 +17,19 @@ $LuaCovRunner = <<_EOC_;
 _EOC_
 }
 
+our @EXPORT = qw(
+    $LuaPackagePath
+    $HttpConfig
+);
+
+our $LuaPackagePath = "lua_package_path './lib/?.lua;./lib/?/init.lua;;';";
+
 our $HttpConfig = <<_EOC_;
-    lua_package_path \'./lib/?.lua;./lib/?/init.lua;;\';
+    $LuaPackagePath
     lua_shared_dict cassandra 1m;
 
     init_by_lua_block {
-      $LuaCovRunner
+        $LuaCovRunner
     }
 _EOC_
 


### PR DESCRIPTION
resty.core makes `ngx.ctx` behave differently than the CFunction-based
implementation in ngx_lua. The latter returns `nil` in init_by_lua*, the
former throws an error.