### PR TITLE
chore(travis) specify trusty dist and pin LuaSec version

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -1,5 +1,7 @@
 set -e
 
+openssl version
+
 # -----------
 # Install ccm
 # -----------
@@ -105,9 +107,7 @@ else
 fi
 
 # init_by_lua + plain Lua dependencies
-luarocks install luasec
+luarocks install luasec 0.6
 luarocks install luasocket
 luarocks install luacov
 luarocks install luacov-coveralls
-
-luarocks --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 
 language: java
 


### PR DESCRIPTION
This is to avoid an issue with the Xenial dist described here:

https://travis-ci.community/t/oracle-jdk-11-and-10-are-pre-installed-not-the-openjdk-builds/785/16

LuaSec 0.6 is pinned to avoid using the latest release which isn't
compatible with OpenSSL 1.0.1 anymore.