### PR TITLE
fix(socket) use cosockets in preread phase

### DIFF
--- a/lib/cassandra/socket.lua
+++ b/lib/cassandra/socket.lua
@@ -121,6 +121,7 @@ local COSOCKET_PHASES = {
   access = true,
   content = true,
   timer = true,
+  preread = true,
   ssl_cert = true,
   ssl_session_fetch = true
 }


### PR DESCRIPTION
Now that we are removing service mesh from Kong the bug which prevented us from using cosockets in the preread phase should be possible. 

The equivalent change in PostgreSQL is part of https://github.com/Kong/kong/pull/5204 (see changes in `kong/db/strategies/postgres/connector.lua`)
