### PR TITLE
feat(socket) exposes TLS protocol encryption version

### DIFF
--- a/docs/examples/ssl.lua
+++ b/docs/examples/ssl.lua
@@ -35,6 +35,7 @@ http {
           contact_points = {"127.0.0.1", "127.0.0.2"},
           keyspace = "my_keyspace",
           ssl = true,
+          encryption_protocol = 'any'
           verify = true
         }
         if not cluster then

--- a/docs/examples/ssl.lua.html
+++ b/docs/examples/ssl.lua.html
@@ -100,6 +100,7 @@ http {
 </span>          contact_points = {<span class="string">"127.0.0.1"</span>, <span class="string">"127.0.0.2"</span>},
           keyspace = <span class="string">"my_keyspace"</span>,
           ssl = <span class="keyword">true</span>,
+          encryption_protocol = <span class="keyword">"any"</span>
           verify = <span class="keyword">true</span>
         }
         <span class="keyword">if</span> <span class="keyword">not</span> cluster <span class="keyword">then</span>

--- a/lib/cassandra/init.lua
+++ b/lib/cassandra/init.lua
@@ -102,6 +102,9 @@ _Host.__index = _Host
 -- (`string`, optional)
 -- @field key Path to the client SSL key (LuaSec usage only).
 -- (`string`, optional)
+-- @field encryption_protocol The client encryption protocol version to use
+-- if `ssl` is enabled (LuaSec usage only).
+-- (`string`, default: `any`)
 -- @field auth Authentication handler, created from the
 -- `cassandra.auth_providers` table. (optional)
 -- @table `client_options`
@@ -134,6 +137,7 @@ function _Host.new(opts)
     verify = opts.verify,
     cert = opts.cert,
     cafile = opts.cafile,
+    encryption_protocol = opts.encryption_protocol,
     key = opts.key,
     auth = opts.auth
   }
@@ -194,6 +198,7 @@ local function ssl_handshake(self)
   local params = {
     key = self.key,
     cafile = self.cafile,
+    encryption_protocol = self.encryption_protocol,
     cert = self.cert
   }
 

--- a/lib/cassandra/socket.lua
+++ b/lib/cassandra/socket.lua
@@ -56,7 +56,7 @@ do
       local ssl = require 'ssl'
       local params = {
         mode = 'client',
-        protocol = 'tlsv1',
+        protocol = opts.encryption_protocol or 'any',
         key = opts.key,
         certificate = opts.cert,
         cafile = opts.cafile,

--- a/lib/resty/cassandra/cluster.lua
+++ b/lib/resty/cassandra/cluster.lua
@@ -372,6 +372,11 @@ function _Cluster.new(opts)
         return nil, 'cafile must be a string'
       end
       peers_opts.cafile = v
+    elseif k == 'encryption_protocol' then
+      if type(v) ~= 'string' then
+        return nil, 'encryption_protocol must be a string'
+      end
+      peers_opts.encryption_protocol = v
     elseif k == 'auth' then
       if type(v) ~= 'table' then
         return nil, 'auth seems not to be an auth provider'

--- a/spec/02-integration/02-ssl_spec.lua
+++ b/spec/02-integration/02-ssl_spec.lua
@@ -31,5 +31,32 @@ describe("SSL", function()
       local rows = assert(peer:execute "SELECT * FROM system.local")
       assert.equal(1, #rows)
     end)
+    it("connects with TLSv1_1 encryption", function()
+      local peer = assert(cassandra.new {
+        ssl = true,
+        encryption_protocol = 'tlsv1_1',
+      })
+      assert(peer:connect())
+      local rows = assert(peer:execute "SELECT * FROM system.local")
+      assert.equal(1, #rows)
+    end)
+    it("connects with TLSv1_2 encryption", function()
+      local peer = assert(cassandra.new {
+        ssl = true,
+        encryption_protocol = 'tlsv1_2',
+      })
+      assert(peer:connect())
+      local rows = assert(peer:execute "SELECT * FROM system.local")
+      assert.equal(1, #rows)
+    end)
+    it("connects with negotiated highest possible encryption", function()
+      local peer = assert(cassandra.new {
+        ssl = true,
+        encryption_protocol = 'any',
+      })
+      assert(peer:connect())
+      local rows = assert(peer:execute "SELECT * FROM system.local")
+      assert.equal(1, #rows)
+    end)
   end)
 end)


### PR DESCRIPTION
Allows changing the TLS encryption version.

The underlying luasec library allows for setting the encryption protocol
to 'any' [1]. When set as such, the client negotiates the highest
encryption protocol available. This `any` protocol version setting is widely in use in the luasec
repository [2].

In my testing, when `any` is set, it resulted in TLSv1.2 being utilized
for the conneciton. While I expected TLSv1.3 to be utilized, after some
  research, I discovered that JDK 8 has had TLSv1.3 support backported
  to it but TLSv1.3 is not enabled by default and requires extra
  configuration when starting the JVM [3]. Thus in practice TLSv1.3 probably wouldn't be enabled very often for Cassandra until a later version of JDK is supported.

Partially implements #106

[1] - https://github.com/brunoos/luasec/blob/711a98b7605ad87b521ba607024947113bc1f527/CHANGELOG#L101
[2] - https://github.com/brunoos/luasec/search?q=protocol+%3D+%22any%22
[3] - https://www.oracle.com/java/technologies/javase/8u261-relnotes.html#JDK-8145252

Signed-off-by: Jeremy J. Miller <jeremy.miller@konghq.com>