### PR TITLE
rockspec: use https instead of git

### DIFF
--- a/lua-cassandra-1.5.2-1.rockspec
+++ b/lua-cassandra-1.5.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "lua-cassandra"
-version = "1.5.2-0"
+version = "1.5.2-1"
 source = {
-  url = "git://github.com/thibaultcha/lua-cassandra",
+  url = "https://github.com/thibaultcha/lua-cassandra",
   tag = "1.5.2"
 }
 description = {

--- a/lua-cassandra-dev-0.rockspec
+++ b/lua-cassandra-dev-0.rockspec
@@ -1,7 +1,7 @@
 package = "lua-cassandra"
 version = "dev-0"
 source = {
-  url = "git://github.com/thibaultcha/lua-cassandra"
+  url = "https://github.com/thibaultcha/lua-cassandra"
 }
 description = {
   summary = "A pure Lua client library for Apache Cassandra",


### PR DESCRIPTION
Using git:// for direct linking is not supported by github any more, so the rock is uninstallable on its current state.

The simplest solution is changing the protocol from git:// to https://, and then push the new rockspec to luarocks.

A workaround exists - you can force git to always use https:// by using these settings:

git config --global url."https://github.com/".insteadOf git@github.com: git config --global url."https://".insteadOf git://

But ideally the rocks should be installable without such global config changes.