### PR TITLE
Update git source URL to include .git at the end

### DIFF
--- a/lua-cassandra-1.5.2-0.rockspec
+++ b/lua-cassandra-1.5.2-0.rockspec
@@ -1,7 +1,7 @@
 package = "lua-cassandra"
 version = "1.5.2-0"
 source = {
-  url = "git://github.com/thibaultcha/lua-cassandra",
+  url = "git@github.com:thibaultcha/lua-cassandra.git",
   tag = "1.5.2"
 }
 description = {


### PR DESCRIPTION
The installation was failing as the script can't clone 'git://github.com/thibaultcha/lua-cassandra' this URL, Updated to 'git@github.com:thibaultcha/lua-cassandra.git' or updating to this http version 'https://github.com/thibaultcha/lua-cassandra' should also work.